### PR TITLE
Support setting timestamp in `validate_cert_trust_chain` and `validate_attestation_doc`

### DIFF
--- a/attestation-doc-validation/src/cert.rs
+++ b/attestation-doc-validation/src/cert.rs
@@ -108,9 +108,9 @@ fn get_epoch() -> CertResult<u64> {
 /// Returns a `CertError::UntrustedCert` when the trust chain fails to validate
 /// Returns a `CertError::Openssl` if an error occurred while preparing the context
 pub fn validate_cert_trust_chain(
-    target: &[u8], 
-    intermediates: &[&[u8]], 
-    time: Option<u64>
+    target: &[u8],
+    intermediates: &[&[u8]],
+    time: Option<u64>,
 ) -> CertResult<()> {
     let end_entity_cert = EndEntityCert::try_from(target).map_err(|_| CertError::DecodeError)?;
 

--- a/attestation-doc-validation/src/lib.rs
+++ b/attestation-doc-validation/src/lib.rs
@@ -61,7 +61,11 @@ pub fn validate_attestation_doc_in_cert(
 
     // Validate that the attestation doc's signature can be tied back to the AWS Nitro CA
     let intermediate_certs = create_intermediate_cert_stack(&decoded_attestation_doc.cabundle);
-    cert::validate_cert_trust_chain(&decoded_attestation_doc.certificate, &intermediate_certs, None)?;
+    cert::validate_cert_trust_chain(
+        &decoded_attestation_doc.certificate,
+        &intermediate_certs,
+        None,
+    )?;
 
     // Validate Cose signature over attestation doc
     let cert = cert::parse_der_cert(&decoded_attestation_doc.certificate)?;
@@ -108,7 +112,11 @@ pub fn validate_attestation_doc_against_cert(
 
     // Validate that the attestation doc's signature can be tied back to the AWS Nitro CA
     let intermediate_certs = create_intermediate_cert_stack(&decoded_attestation_doc.cabundle);
-    cert::validate_cert_trust_chain(&decoded_attestation_doc.certificate, &intermediate_certs, None)?;
+    cert::validate_cert_trust_chain(
+        &decoded_attestation_doc.certificate,
+        &intermediate_certs,
+        None,
+    )?;
 
     // Validate Cose signature over attestation doc
     let pub_key: nsm::PublicKey = attestation_doc_signing_cert.public_key().try_into()?;
@@ -153,7 +161,11 @@ pub fn validate_attestation_doc(
 
     // Validate that the attestation doc's signature can be tied back to the AWS Nitro CA
     let intermediate_certs = create_intermediate_cert_stack(&decoded_attestation_doc.cabundle);
-    cert::validate_cert_trust_chain(&decoded_attestation_doc.certificate, &intermediate_certs, time)?;
+    cert::validate_cert_trust_chain(
+        &decoded_attestation_doc.certificate,
+        &intermediate_certs,
+        time,
+    )?;
 
     // Validate Cose signature over attestation doc
     let pub_key: nsm::PublicKey = attestation_doc_signing_cert.public_key().try_into()?;
@@ -186,7 +198,11 @@ pub fn validate_and_parse_attestation_doc(
 
     // Validate that the attestation doc's signature can be tied back to the AWS Nitro CA
     let intermediate_certs = create_intermediate_cert_stack(&decoded_attestation_doc.cabundle);
-    cert::validate_cert_trust_chain(&decoded_attestation_doc.certificate, &intermediate_certs, None)?;
+    cert::validate_cert_trust_chain(
+        &decoded_attestation_doc.certificate,
+        &intermediate_certs,
+        None,
+    )?;
 
     // Validate Cose signature over attestation doc
     let pub_key: nsm::PublicKey = attestation_doc_signing_cert.public_key().try_into()?;


### PR DESCRIPTION
# Why
* Attestation docs are only valid for 3 hours. We want to verify attestation docs beyond their expiry time.

# How
* Add optional `time` parameter to `validate_cert_trust_chain` and `validate_attestation_doc` functions.
* There's a bunch of other `validate_attestation...` functions, such as `validate_attestation_doc_in_cert`, etc. I haven't bothered updating those to have a `time` parameter, because we won't be using those yet. They just pass `None` to the `validate_cert_trust_chain` function.
* This may break the bindings (to Node, Python etc), because I've added another parameter to the public `validate_attestation_doc` function. We're not planning to use the bindings yet though, so I think it's fine to not bother updating them yet. If we want to get this upstream into the actual attestation-doc-validation crate, I imagine we'd need to do that.

# Security / Environment Variables (if applicable)
* This allows the verification of expired certs, so it should only be used in cases where that is useful, and not when using attestation docs for real-time authentication.

# Testing
* Added a test on one of the existing test data examples, setting the timestamp to a time when that attestation doc was valid (which I found in their tests that use faketime). The test passes.
* You can run the tests by cloning and doing `cargo make test`